### PR TITLE
fix: Use rpm-ostree in steamos-update

### DIFF
--- a/usr/bin/steamos-update
+++ b/usr/bin/steamos-update
@@ -1,12 +1,12 @@
 #! /bin/bash
 
-if command -v frzr-deploy > /dev/null; then
+if command -v rpm-ostree > /dev/null; then
 	if [ "$1" == "check" ]; then
-		frzr-deploy --check
+		rpm-ostree upgrade
 	elif [ "$1" == "--supports-duplicate-detection" ]; then
 		exit 0
 	else
-		frzr-deploy --steam-progress
+		rpm-ostree upgrade
 	fi
 else
     exit 7


### PR DESCRIPTION
This replaces frzr (used in ChimeraOS) with rpm-ostree. Unfortunately, we don't have a way of informing Steam via rpm-ostree that an update is actually available like frzr does on ChimeraOS so just update on checks as well