### PR TITLE
feat: Implement support for OpenGamepadUI Quick Access Menu

### DIFF
--- a/gamescope-session.spec
+++ b/gamescope-session.spec
@@ -34,6 +34,7 @@ mkdir -p %{buildroot}%{_datadir}/
 mkdir -p %{buildroot}%{_userunitdir}/
 cp -rv usr/bin/* %{buildroot}%{_bindir}
 cp -rv usr/share/* %{buildroot}%{_datadir}
+cp -v usr/etc/default/* %{buildroot}%{_prefix}/etc/default
 cp -v usr/lib/systemd/user/* %{buildroot}%{_userunitdir}
 rm -rf %{buildroot}%{_bindir}/steamos-polkit-helpers
 rm %{buildroot}%{_bindir}/jupiter-biosupdate
@@ -64,6 +65,7 @@ rm %{buildroot}%{_bindir}/steamos-update
 %{_datadir}/gamescope-session/gamescope-session-script
 %{_datadir}/polkit-1/actions/org.chimeraos.update.policy
 %{_datadir}/wayland-sessions/gamescope-session.desktop
+%{_prefix}/etc/default/ogui-qam
 %{_userunitdir}/gamescope-session.service
 
 # Finally, changes from the latest release of your application are generated from

--- a/usr/etc/default/ogui-qam
+++ b/usr/etc/default/ogui-qam
@@ -1,0 +1,1 @@
+OGUI_QAM=false

--- a/usr/share/gamescope-session/gamescope-session-script
+++ b/usr/share/gamescope-session/gamescope-session-script
@@ -197,6 +197,9 @@ fi
 if [ -z "$STEAMCMD" ] ; then
     STEAMCMD="steam -gamepadui -steamos3 -steampal -steamdeck"
 fi
+if [ -z "$OGUICMD" ] ; then
+    OGUICMD="opengamepadui --only-qam -- $STEAMCMD"
+fi
 
 if [ -z "$GAMESCOPECMD" ] ; then
     RESOLUTION=""
@@ -286,6 +289,9 @@ fi
 if [ -f "${HOME}"/.gamescope-cmd.log ]; then
     cp "${HOME}"/.gamescope-cmd.log "${HOME}"/.gamescope-cmd.log.old
 fi
+if [ -f "${HOME}"/.ogui-stdout.log ]; then
+    cp "${HOME}"/.ogui-stdout.log "${HOME}"/.ogui-stdout.log.old
+fi
 
 # Start gamescope compositor, log it's output and background it
 echo $GAMESCOPECMD > "${HOME}"/.gamescope-cmd.log
@@ -340,6 +346,9 @@ fi
 
 # Start Steam client
 $STEAMCMD > "${HOME}"/.steam-stdout.log 2>&1
+
+# Start OGUI in qam-only mode
+$OGUICMD > "${HOME}"/.ogui-stdout.log 2>&1
 
 if [[ "$SECONDS" -lt "$short_session_duration" ]]; then
 	echo "steam failed" >> "$short_session_tracker_file"

--- a/usr/share/gamescope-session/gamescope-session-script
+++ b/usr/share/gamescope-session/gamescope-session-script
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+source /etc/default/ogui-qam
+
 # Reset System76-Scheduler Foreground Process
 dbus-send --system --dest=com.system76.Scheduler \
     /com/system76/Scheduler \
@@ -197,8 +199,10 @@ fi
 if [ -z "$STEAMCMD" ] ; then
     STEAMCMD="steam -gamepadui -steamos3 -steampal -steamdeck"
 fi
-if [ -z "$OGUICMD" ] ; then
-    OGUICMD="opengamepadui --only-qam -- $STEAMCMD"
+if ${OGUI_QAM}; then
+    if [ -z "$OGUICMD" ] ; then
+        OGUICMD="opengamepadui --only-qam -- $STEAMCMD"
+    fi
 fi
 
 if [ -z "$GAMESCOPECMD" ] ; then
@@ -289,8 +293,10 @@ fi
 if [ -f "${HOME}"/.gamescope-cmd.log ]; then
     cp "${HOME}"/.gamescope-cmd.log "${HOME}"/.gamescope-cmd.log.old
 fi
-if [ -f "${HOME}"/.ogui-stdout.log ]; then
-    cp "${HOME}"/.ogui-stdout.log "${HOME}"/.ogui-stdout.log.old
+if ${OGUI_QAM}; then
+    if [ -f "${HOME}"/.ogui-stdout.log ]; then
+        cp "${HOME}"/.ogui-stdout.log "${HOME}"/.ogui-stdout.log.old
+    fi
 fi
 
 # Start gamescope compositor, log it's output and background it
@@ -344,11 +350,13 @@ if command -v mangoapp > /dev/null; then
     mangoapp > "${HOME}"/.mangoapp-stdout.log 2>&1 &
 fi
 
-# Start Steam client
-$STEAMCMD > "${HOME}"/.steam-stdout.log 2>&1
-
-# Start OGUI in qam-only mode
-$OGUICMD > "${HOME}"/.ogui-stdout.log 2>&1
+if ${OGUI_QAM}; then
+    # Start OGUI in qam-only mode
+    $OGUICMD > "${HOME}"/.ogui-stdout.log 2>&1
+else
+    # Start Steam client
+    $STEAMCMD > "${HOME}"/.steam-stdout.log 2>&1
+fi
 
 if [[ "$SECONDS" -lt "$short_session_duration" ]]; then
 	echo "steam failed" >> "$short_session_tracker_file"


### PR DESCRIPTION
Implements support for the OpenGamepadUI Quick Access Menu. Removes the need for the service that controls this and otherwise duplicate session script. Uses an environment variable for toggling support instead of a separate service and script implementation. Disabled by default.