### PR TITLE
Remove refresh rate limits from legion go

### DIFF
--- a/usr/share/gamescope-session-plus/device-quirks
+++ b/usr/share/gamescope-session-plus/device-quirks
@@ -292,6 +292,9 @@ if [[ ":83E1:" =~ ":$SYS_ID:"  ]]; then
       --force-orientation left "
   fi
   # Set refresh rate range and enable refresh rate switching
-  export STEAM_DISPLAY_REFRESH_LIMITS=${GAMESCOPE_OVERRIDE_REFRESH_RATE:-60,144}
+  # With the latest gamescope patch, the unified framerate slider works correctly
+  # By enabling the option below, if unified refresh rate is disabled, the refresh
+  # rate slider can appear, which leads users into footgunning themselves.
+  # export STEAM_DISPLAY_REFRESH_LIMITS=${GAMESCOPE_OVERRIDE_REFRESH_RATE:-60,144}
 fi
 


### PR DESCRIPTION
As of the latest Bazzite update, the unified slider works correctly from switching between 60 and 144hz.

The quirk below enables the refresh rate slider when the unified slider is disabled, which can lead the display into going into a bad state.