### PR TITLE
Change panel type from external to internal for Ayn Loki devices

### DIFF
--- a/usr/share/gamescope-session-plus/device-quirks
+++ b/usr/share/gamescope-session-plus/device-quirks
@@ -105,7 +105,7 @@ fi
 AYN_LIST="Loki Max:Loki Zero:Loki MiniPro"
 if [[ ":$AYN_LIST:" =~ ":$SYS_ID:"  ]]; then
   # Dependent on a special --force-external-orientation option in gamescope
-  if ( gamescope --help 2>&1 | grep -e "--force-external-orientation" > /dev/null ) ; then
+  if ( gamescope --help 2>&1 | grep -e "--force-orientation" > /dev/null ) ; then
     export GAMESCOPECMD="/usr/bin/gamescope \
       -e \
       --generate-drm-mode fixed \
@@ -115,8 +115,7 @@ if [[ ":$AYN_LIST:" =~ ":$SYS_ID:"  ]]; then
       --hide-cursor-delay $CURSOR_DELAY \
       --fade-out-duration 200 \
       --cursor-scale-height 720 \
-      --force-panel-type external \
-      --force-external-orientation left "
+      --force-orientation left "
   fi
   # Set refresh rate range and enable refresh rate switching
   export STEAM_DISPLAY_REFRESH_LIMITS=${GAMESCOPE_OVERRIDE_REFRESH_RATE:-40,60}


### PR DESCRIPTION
Combined with https://github.com/ublue-os/bazzite/pull/947 this allows to have 40/50/60hz on loki devices