### PR TITLE
fix: correctly run check for sdl/legacy cards

### DIFF
--- a/usr/share/gamescope-session-plus/gamescope-session-plus
+++ b/usr/share/gamescope-session-plus/gamescope-session-plus
@@ -25,14 +25,13 @@ post_gamescope_start() {
 get_gamescope_binary() {
 	if [ -n "$GAMESCOPE_BIN" ]; then
 		echo $GAMESCOPE_BIN
-	elif [ -f /usr/libexec/gamescope-sdl-workaround ] && command -v /usr/bin/gamescope-legacy > /dev/null; then
+	elif /usr/libexec/gamescope-sdl-workaround && command -v /usr/bin/gamescope-legacy > /dev/null; then
 		# GPUs that require the SDL backend
 		echo "/usr/bin/gamescope-legacy"
 	else
 		echo "/usr/bin/gamescope"
 	fi
 }
-
 gamescope_has_option() {
 	if ($(get_gamescope_binary) --help 2>&1 | grep -e "$1" > /dev/null); then
 		return 0


### PR DESCRIPTION
if condition has to run the file, not check for its existence (which will always be true)
This broke in this commit https://github.com/ChimeraOS/gamescope-session/commit/b4a4d9fc1f22ee460355bbbf010fca6069c356a8