### PR TITLE
feat: add dmi for onexfly with 8840U cpu

### DIFF
--- a/usr/share/gamescope-session-plus/device-quirks
+++ b/usr/share/gamescope-session-plus/device-quirks
@@ -22,7 +22,7 @@ if [[ ":$OXP_LIST:" =~ ":$SYS_ID:"  ]] || [[  ":$AOK_LIST:" =~ ":$SYS_ID:"   ]];
 fi
 
 # OXP 120Hz Devices
-OXP_120_LIST="ONEXPLAYER F1"
+OXP_120_LIST="ONEXPLAYER F1:ONEXPLAYER F1L"
 if [[ ":$OXP_120_LIST:" =~ ":$SYS_ID:"  ]]; then
   PANEL_TYPE=external
   ORIENTATION=left


### PR DESCRIPTION
Fixes the rotation on the `ONEXPLAYER F1L` (the version with the 8840U)