### PR TITLE
add headless option

### DIFF
--- a/usr/share/gamescope-session-plus/gamescope-session-plus
+++ b/usr/share/gamescope-session-plus/gamescope-session-plus
@@ -234,6 +234,11 @@ if [ -z "$GAMESCOPECMD" ]; then
 		DISABLE_TOUCH_CLICK_OPTION="--disable-touch-click"
 	fi
 
+	HEADLESS_OPTION=""
+	if [ -n "$HEADLESS" ] && gamescope_has_option "--headless"; then
+		HEADLESS_OPTION="--headless"
+	fi
+
 	GAMESCOPECMD="$(get_gamescope_binary) \
 		$CURSOR \
 		$RESOLUTION \
@@ -246,6 +251,7 @@ if [ -z "$GAMESCOPECMD" ]; then
 		$CUSTOM_REFRESH_RATES_OPTION \
 		$BACKEND_OPTION \
 		$DISABLE_TOUCH_CLICK_OPTION \
+		$HEADLESS_OPTION \
 		--prefer-output $OUTPUT_CONNECTOR \
 		--xwayland-count $XWAYLAND_COUNT \
 		--default-touch-mode $TOUCH_MODE \


### PR DESCRIPTION
This adds the `--headless` option to gamescope. Example (my) usecase: headless streaming server, without a dummy HDMI plug.